### PR TITLE
Fix scalyr.query action, add 3 new actions (power_query, timeseries_query, timeseries_queries) and 2 action aliases

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,13 @@
+# Change Log
+
+## v0.1.0
+
+- Fix ``scalyr.query`` action so it works correctly. Also fix parameter name from 
+  ``fromTime`` / ``toTime`` to ``startTime`` / ``endTime`` and add new ``priority``
+  and ``columns`` parameter.
+- Add new ``scalyr.power_query`` action.
+- Add new ``scalyr.timeseries_query`` action.
+
+## v0.0.1
+
+- Initial release.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,13 +2,15 @@
 
 ## v0.1.0
 
-- Fix ``scalyr.query`` action so it works correctly. Also fix parameter name from 
+- Fix ``scalyr.query`` action so it works correctly. Also fix parameter name from
   ``fromTime`` / ``toTime`` to ``startTime`` / ``endTime`` and add new ``priority``
   and ``columns`` parameter.
 - Add new ``scalyr.power_query`` action.
 - Add new ``scalyr.timeseries_query`` action.
 - Add new ``scalyr.timeseries_queries`` action.
 - Add new action aliases.
+- In addition to ``token`` also allow base API endpoint url to be overriden on action
+  execution basis using ``api_url`` action parameter.
 
 ## v0.0.1
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,8 @@
   and ``columns`` parameter.
 - Add new ``scalyr.power_query`` action.
 - Add new ``scalyr.timeseries_query`` action.
+- Add new ``scalyr.timeseries_queries`` action.
+- Add new action aliases.
 
 ## v0.0.1
 

--- a/actions/base.py
+++ b/actions/base.py
@@ -1,0 +1,75 @@
+# Copyright 2020 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if False:
+    from typing import Optional
+    from typing import Tuple
+
+import copy
+import json
+
+import requests
+
+from st2common.runners.base_action import Action
+
+__all__ = ["BaseScalyrAction"]
+
+
+class BaseScalyrAction(Action):
+    def _send_api_request(self, path, data, api_url=None, token=None):
+        # type: (str, dict, Optional[str], Optional[str]) -> Tuple[bool, dict]
+        """
+        Perform Scalyr API request and return the parsed response.
+        """
+        if api_url:
+            self.logger.debug("Using api_url which was passed as parameter to the action")
+        else:
+            self.logger.debug("using url from the pack config")
+
+        if token:
+            self.logger.debug("Using token which was passed as parameter to the action")
+        else:
+            self.logger.debug("using token from the pack config")
+
+        api_url = api_url or self.config["url"]
+        token = token or self.config["token"]
+
+        data["token"] = token
+
+        data_to_log = copy.copy(data)
+
+        if "token" in data_to_log:
+            data_to_log["token"] = "************"
+
+        url = api_url + path
+        serialized_data = json.dumps(data)
+
+        self.logger.debug("Using API endpoint: {}".format(api_url))
+        self.logger.debug("Using API operation URL: {}".format(url))
+        self.logger.debug("Using POST body data {}".format(serialized_data))
+
+        headers = {"Content-Type": "application/json"}
+        response = requests.request('POST', url=url, headers=headers, data=serialized_data)
+        ok = response.ok
+
+        self.logger.debug("Request {}, fetched {} ({})".format("OK" if ok else "failed",
+                                                               response.text, response.status_code))
+
+        try:
+            result = response.json()
+        except Exception:
+            result = response.text
+
+        self.logger.debug("Fetched {}".format(result))
+        return (ok, result)

--- a/actions/power_query.py
+++ b/actions/power_query.py
@@ -1,15 +1,25 @@
-import json
-import copy
+# Copyright 2020 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-import requests
-
-from st2common.runners.base_action import Action
+from base import BaseScalyrAction
 
 __all__ = ['PowerQueryAction']
 
 
-class PowerQueryAction(Action):
-    def run(self, query, startTime=None, endTime=None, columns=None, priority="low", token=None):
+class PowerQueryAction(BaseScalyrAction):
+    def run(self, query, startTime=None, endTime=None, columns=None, priority="low", api_url=None,
+            token=None):
         data = {
             "query": query,
         }
@@ -20,28 +30,6 @@ class PowerQueryAction(Action):
         if endTime:
             data["endTime"] = startTime
 
-        if not token:
-            data["token"] = self.config["token"]
-
-        kwargs_to_log = copy.copy(data)
-
-        if "token" in kwargs_to_log:
-            kwargs_to_log["token"] = "************"
-
-        self.logger.info("Called with {0}".format(kwargs_to_log))
-
-        url = self.config['url'] + "/powerQuery"
-
-        headers = {"Content-Type": "application/json"}
-        response = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
-
-        ok = response.ok
-        self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", response.text))
-
-        try:
-            result = response.json()
-        except Exception:
-            result = response.text
-
-        self.logger.debug("Fetched {}".format(result))
+        ok, result = self._send_api_request(path="/powerQuery", data=data, api_url=api_url,
+                                            token=token)
         return (ok, result)

--- a/actions/power_query.py
+++ b/actions/power_query.py
@@ -33,10 +33,15 @@ class PowerQueryAction(Action):
         url = self.config['url'] + "/powerQuery"
 
         headers = {"Content-Type": "application/json"}
-        results = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
+        response = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
 
-        ok = results.ok
-        self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", results.text))
-        results = results.json() if ok else results.text
-        self.logger.info("Fetched {}".format(results))
-        return (ok, results)
+        ok = response.ok
+        self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", response.text))
+
+        try:
+            result = response.json()
+        except Exception:
+            result = response.text
+
+        self.logger.debug("Fetched {}".format(result))
+        return (ok, result)

--- a/actions/power_query.py
+++ b/actions/power_query.py
@@ -1,0 +1,42 @@
+import json
+import copy
+
+import requests
+
+from st2common.runners.base_action import Action
+
+__all__ = ['PowerQueryAction']
+
+
+class PowerQueryAction(Action):
+    def run(self, query, startTime=None, endTime=None, columns=None, priority="low", token=None):
+        data = {
+            "query": query,
+        }
+
+        if startTime:
+            data["startTime"] = startTime
+
+        if endTime:
+            data["endTime"] = startTime
+
+        if not token:
+            data["token"] = self.config["token"]
+
+        kwargs_to_log = copy.copy(data)
+
+        if "token" in kwargs_to_log:
+            kwargs_to_log["token"] = "************"
+
+        self.logger.info("Called with {0}".format(kwargs_to_log))
+
+        url = self.config['url'] + "/powerQuery"
+
+        headers = {"Content-Type": "application/json"}
+        results = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
+
+        ok = results.ok
+        self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", results.text))
+        results = results.json() if ok else results.text
+        self.logger.info("Fetched {}".format(results))
+        return (ok, results)

--- a/actions/power_query.yaml
+++ b/actions/power_query.yaml
@@ -22,6 +22,9 @@ parameters:
         - "low"
         - "high"
       description: "Query priority."
+    api_url:
+      type: string
+      description: "API url, that overrides the one provided by the config.yaml"
     token:
       type: string
       description: "API token, that overrides the one provided by the config.yaml"

--- a/actions/power_query.yaml
+++ b/actions/power_query.yaml
@@ -1,0 +1,28 @@
+---
+name: power_query
+pack: scalyr
+runner_type: python-script
+description: "Run Scalyr PowerQuery"
+entry_point: power_query.py
+parameters:
+    query:
+      type: string
+      description: "Query to execute in PowerQuery language"
+      required: True
+    startTime:
+      type: string
+      description: "Start of time interval, in variety of formats, e.g. 10:30, see https://www.scalyr.com/help/time-reference"
+    endTime:
+      type: string
+      description: "End of time interval, in variety of formats, e.g. 11:30, see https://www.scalyr.com/help/time-reference"
+    priority:
+      type: string
+      default: low
+      enum:
+        - "low"
+        - "high"
+      description: "Query priority."
+    token:
+      type: string
+      description: "API token, that overrides the one provided by the config.yaml"
+      secret: True

--- a/actions/query.py
+++ b/actions/query.py
@@ -1,16 +1,25 @@
-import json
-import copy
+# Copyright 2020 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-import requests
-
-from st2common.runners.base_action import Action
+from base import BaseScalyrAction
 
 __all__ = ['QueryAction']
 
 
-class QueryAction(Action):
+class QueryAction(BaseScalyrAction):
     def run(self, filter="", maxCount=100, startTime=None, endTime=None, columns=None,
-            priority="low", token=None):
+            priority="low", api_url=None, token=None):
         data = {
             "queryType": "log",
             "filter": filter,
@@ -23,31 +32,6 @@ class QueryAction(Action):
         if endTime:
             data["endTime"] = startTime
 
-        if not token:
-            data["token"] = self.config["token"]
-
-        kwargs_to_log = copy.copy(data)
-
-        if "token" in kwargs_to_log:
-            kwargs_to_log["token"] = "************"
-
-        self.logger.info("Called with {0}".format(kwargs_to_log))
-
-        url = self.config['url'] + "/query"
-
-        headers = {"Content-Type": "application/json"}
-        response = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
-
-        ok = response.ok
-        self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", response.text))
-
-        try:
-            result = response.json()
-        except Exception:
-            result = response.text
-
-        if not ok:
-            return (False, result)
-
-        self.logger.debug("Fetched {}".format(result))
+        ok, result = self._send_api_request(path="/query", data=data, api_url=api_url,
+                                            token=token)
         return (ok, result)

--- a/actions/query.py
+++ b/actions/query.py
@@ -36,10 +36,18 @@ class QueryAction(Action):
         url = self.config['url'] + "/query"
 
         headers = {"Content-Type": "application/json"}
-        results = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
+        response = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
 
-        ok = results.ok
-        self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", results.text))
-        results = results.json() if ok else results.text
-        self.logger.info("Fetched {}".format(results))
-        return (ok, results)
+        ok = response.ok
+        self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", response.text))
+
+        try:
+            result = response.json()
+        except Exception:
+            result = response.text
+
+        if not ok:
+            return (False, result)
+
+        self.logger.debug("Fetched {}".format(result))
+        return (ok, result)

--- a/actions/query.py
+++ b/actions/query.py
@@ -1,23 +1,42 @@
-from st2common.runners.base_action import Action
-import requests
 import json
+import copy
+
+import requests
+
+from st2common.runners.base_action import Action
 
 __all__ = ['QueryAction']
 
 
 class QueryAction(Action):
-    def run(self, **kwargs):
+    def run(self, filter="", maxCount=100, startTime=None, endTime=None, columns=None,
+            priority="low", token=None):
+        data = {
+            "queryType": "log",
+            "filter": filter,
+            "maxCount": maxCount,
+        }
 
-        self.logger.info("Called with {0}".format(kwargs))
+        if startTime:
+            data["startTime"] = startTime
+
+        if endTime:
+            data["endTime"] = startTime
+
+        if not token:
+            data["token"] = self.config["token"]
+
+        kwargs_to_log = copy.copy(data)
+
+        if "token" in kwargs_to_log:
+            kwargs_to_log["token"] = "************"
+
+        self.logger.info("Called with {0}".format(kwargs_to_log))
 
         url = self.config['url'] + "/query"
-        kwargs['queryType'] = 'log'
-        if kwargs['token'] is None:
-            kwargs['token'] = self.config['token']
-        if not kwargs['filter']:
-            kwargs['filter'] = ""
 
-        results = requests.request('POST', url=url, data=json.dumps(kwargs))
+        headers = {"Content-Type": "application/json"}
+        results = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
 
         ok = results.ok
         self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", results.text))

--- a/actions/query.yaml
+++ b/actions/query.yaml
@@ -14,12 +14,22 @@ parameters:
       type: integer
       description: "Maximum number of records to return."
       default: 100
-    fromTime:
+    startTime:
       type: string
       description: "Start of time interval, in variety of formats, e.g. 10:30, see https://www.scalyr.com/help/time-reference"
-    toTime:
+    endTime:
       type: string
       description: "End of time interval, in variety of formats, e.g. 11:30, see https://www.scalyr.com/help/time-reference"
+    columns:
+      type: string
+      description: " specifies which fields to return for each log message, as a comma-delimited list. Omit this parameter (or pass an empty string) to return all fields."
+    priority:
+      type: string
+      default: low
+      enum:
+        - "low"
+        - "high"
+      description: "Query priority."
     token:
       type: string
       description: "API token, that overrides the one provided by the config.yaml"

--- a/actions/timeseries_queries.py
+++ b/actions/timeseries_queries.py
@@ -1,15 +1,24 @@
-import json
-import copy
+# Copyright 2020 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-import requests
-
-from st2common.runners.base_action import Action
+from base import BaseScalyrAction
 
 __all__ = ['TimeseriesQueryAction']
 
 
-class TimeseriesQueryAction(Action):
-    def run(self, queries, token=None):
+class TimeseriesQueryAction(BaseScalyrAction):
+    def run(self, queries, api_url=None, token=None):
 
         data = {
             "queries": []
@@ -39,28 +48,6 @@ class TimeseriesQueryAction(Action):
 
             data["queries"].append(query_item)
 
-        if not token:
-            data["token"] = self.config["token"]
-
-        kwargs_to_log = copy.copy(data)
-
-        if "token" in kwargs_to_log:
-            kwargs_to_log["token"] = "************"
-
-        self.logger.info("Called with {0}".format(kwargs_to_log))
-
-        url = self.config['url'] + "/timeseriesQuery"
-
-        headers = {"Content-Type": "application/json"}
-        response = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
-
-        ok = response.ok
-        self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", response.text))
-
-        try:
-            result = response.json()
-        except Exception:
-            result = response.text
-
-        self.logger.info("Fetched {}".format(result))
+        ok, result = self._send_api_request(path="/timeseriesQuery", data=data, api_url=api_url,
+                                            token=token)
         return (ok, result)

--- a/actions/timeseries_queries.py
+++ b/actions/timeseries_queries.py
@@ -26,16 +26,16 @@ class TimeseriesQueryAction(Action):
                 query_item["function"] = query["function"]
 
             if query.get("startTime", None):
-                query_item["startTime"] =  query["startTime"]
+                query_item["startTime"] = query["startTime"]
 
             if query.get("endTime", None):
-                query_item["endTime"] =  query["endTime"]
+                query_item["endTime"] = query["endTime"]
 
             if query.get("buckets", None):
-                query_item["buckets"] =  query["buckets"]
+                query_item["buckets"] = query["buckets"]
 
             if query.get("priority", None):
-                query_item["priority"] =  query["priority"]
+                query_item["priority"] = query["priority"]
 
             data["queries"].append(query_item)
 

--- a/actions/timeseries_queries.py
+++ b/actions/timeseries_queries.py
@@ -19,7 +19,6 @@ __all__ = ['TimeseriesQueryAction']
 
 class TimeseriesQueryAction(BaseScalyrAction):
     def run(self, queries, api_url=None, token=None):
-
         data = {
             "queries": []
         }

--- a/actions/timeseries_queries.py
+++ b/actions/timeseries_queries.py
@@ -16,7 +16,7 @@ class TimeseriesQueryAction(Action):
         }
 
         for query in queries:
-            # Each item can container: filter, function, startTinme, endTime, buckets, priority
+            # Each item can contain: filter, function, startTinme, endTime, buckets, priority
             query_item = {}
 
             if query.get("filter", None):

--- a/actions/timeseries_queries.py
+++ b/actions/timeseries_queries.py
@@ -1,0 +1,66 @@
+import json
+import copy
+
+import requests
+
+from st2common.runners.base_action import Action
+
+__all__ = ['TimeseriesQueryAction']
+
+
+class TimeseriesQueryAction(Action):
+    def run(self, queries, token=None):
+
+        data = {
+            "queries": []
+        }
+
+        for query in queries:
+            # Each item can container: filter, function, startTinme, endTime, buckets, priority
+            query_item = {}
+
+            if query.get("filter", None):
+                query_item["filter"] = query["filter"]
+
+            if query.get("function", None):
+                query_item["function"] = query["function"]
+
+            if query.get("startTime", None):
+                query_item["startTime"] =  query["startTime"]
+
+            if query.get("endTime", None):
+                query_item["endTime"] =  query["endTime"]
+
+            if query.get("buckets", None):
+                query_item["buckets"] =  query["buckets"]
+
+            if query.get("priority", None):
+                query_item["priority"] =  query["priority"]
+
+            data["queries"].append(query_item)
+
+        if not token:
+            data["token"] = self.config["token"]
+
+        kwargs_to_log = copy.copy(data)
+
+        if "token" in kwargs_to_log:
+            kwargs_to_log["token"] = "************"
+
+        self.logger.info("Called with {0}".format(kwargs_to_log))
+
+        url = self.config['url'] + "/timeseriesQuery"
+
+        headers = {"Content-Type": "application/json"}
+        response = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
+
+        ok = response.ok
+        self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", response.text))
+
+        try:
+            result = response.json()
+        except Exception:
+            result = response.text
+
+        self.logger.info("Fetched {}".format(result))
+        return (ok, result)

--- a/actions/timeseries_queries.yaml
+++ b/actions/timeseries_queries.yaml
@@ -1,0 +1,38 @@
+---
+name: timeseries_queries
+pack: scalyr
+runner_type: python-script
+description: "Run multiple Scalyr timeseries queries"
+entry_point: timeseries_queries.py
+parameters:
+    queries:
+      description: "Timeseries query objects to execute"
+      type: array
+      items:
+        type: object
+        additionalProperties: false
+        properties:
+          filter:
+            type: string
+            required: true
+          function:
+            type: string
+          startTime:
+            type: string
+            default: "10 minutes"
+          endTime:
+            type: string
+          buckets:
+            type: integer
+            default: 1
+          priority:
+            type: string
+            enum:
+              - "low"
+              - "high"
+            default: "low"
+      required: True
+    token:
+      type: string
+      description: "API token, that overrides the one provided by the config.yaml"
+      secret: True

--- a/actions/timeseries_queries.yaml
+++ b/actions/timeseries_queries.yaml
@@ -32,6 +32,9 @@ parameters:
               - "high"
             default: "low"
       required: True
+    api_url:
+      type: string
+      description: "API url, that overrides the one provided by the config.yaml"
     token:
       type: string
       description: "API token, that overrides the one provided by the config.yaml"

--- a/actions/timeseries_query.py
+++ b/actions/timeseries_query.py
@@ -1,16 +1,25 @@
-import json
-import copy
+# Copyright 2020 The StackStorm Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
-import requests
-
-from st2common.runners.base_action import Action
+from base import BaseScalyrAction
 
 __all__ = ['TimeseriesQueryAction']
 
 
-class TimeseriesQueryAction(Action):
+class TimeseriesQueryAction(BaseScalyrAction):
     def run(self, filter, function=None, startTime=None, endTime=None, buckets=None,
-            priority="low", token=None):
+            priority="low", api_url, token=None):
         data = {
             "queries": [{}]
         }
@@ -33,28 +42,6 @@ class TimeseriesQueryAction(Action):
         if priority:
             data["queries"][0]["priority"] = priority
 
-        if not token:
-            data["token"] = self.config["token"]
-
-        kwargs_to_log = copy.copy(data)
-
-        if "token" in kwargs_to_log:
-            kwargs_to_log["token"] = "************"
-
-        self.logger.info("Called with {0}".format(kwargs_to_log))
-
-        url = self.config['url'] + "/timeseriesQuery"
-
-        headers = {"Content-Type": "application/json"}
-        response = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
-
-        ok = response.ok
-        self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", response.text))
-
-        try:
-            result = response.json()
-        except Exception:
-            result = response.text
-
-        self.logger.info("Fetched {}".format(result))
+        ok, result = self._send_api_request(path="/timeseriesQuery", data=data, api_url=api_url,
+                                            token=token)
         return (ok, result)

--- a/actions/timeseries_query.py
+++ b/actions/timeseries_query.py
@@ -46,10 +46,15 @@ class TimeseriesQueryAction(Action):
         url = self.config['url'] + "/timeseriesQuery"
 
         headers = {"Content-Type": "application/json"}
-        results = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
+        response = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
 
-        ok = results.ok
-        self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", results.text))
-        results = results.json() if ok else results.text
-        self.logger.info("Fetched {}".format(results))
-        return (ok, results)
+        ok = response.ok
+        self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", response.text))
+
+        try:
+            result = response.json()
+        except Exception:
+            result = response.text
+
+        self.logger.info("Fetched {}".format(result))
+        return (ok, result)

--- a/actions/timeseries_query.py
+++ b/actions/timeseries_query.py
@@ -1,0 +1,55 @@
+import json
+import copy
+
+import requests
+
+from st2common.runners.base_action import Action
+
+__all__ = ['TimeseriesQueryAction']
+
+
+class TimeseriesQueryAction(Action):
+    def run(self, filter, function=None, startTime=None, endTime=None, buckets=None,
+            priority="low", token=None):
+        data = {
+            "queries": [{}]
+        }
+
+        if filter:
+            data["queries"][0]["filter"] = filter
+
+        if function:
+            data["queries"][0]["function"] = function
+
+        if startTime:
+            data["queries"][0]["startTime"] = startTime
+
+        if endTime:
+            data["queries"][0]["endTime"] = startTime
+
+        if buckets:
+            data["queries"][0]["buckets"] = buckets
+
+        if priority:
+            data["queries"][0]["priority"] = priority
+
+        if not token:
+            data["token"] = self.config["token"]
+
+        kwargs_to_log = copy.copy(data)
+
+        if "token" in kwargs_to_log:
+            kwargs_to_log["token"] = "************"
+
+        self.logger.info("Called with {0}".format(kwargs_to_log))
+
+        url = self.config['url'] + "/timeseriesQuery"
+
+        headers = {"Content-Type": "application/json"}
+        results = requests.request('POST', url=url, headers=headers, data=json.dumps(data))
+
+        ok = results.ok
+        self.logger.debug("Request {}, fetched {}".format("OK" if ok else "failed", results.text))
+        results = results.json() if ok else results.text
+        self.logger.info("Fetched {}".format(results))
+        return (ok, results)

--- a/actions/timeseries_query.py
+++ b/actions/timeseries_query.py
@@ -19,7 +19,7 @@ __all__ = ['TimeseriesQueryAction']
 
 class TimeseriesQueryAction(BaseScalyrAction):
     def run(self, filter, function=None, startTime=None, endTime=None, buckets=None,
-            priority="low", api_url, token=None):
+            priority="low", api_url=None, token=None):
         data = {
             "queries": [{}]
         }

--- a/actions/timeseries_query.yaml
+++ b/actions/timeseries_query.yaml
@@ -28,6 +28,9 @@ parameters:
         - "low"
         - "high"
       description: "Query priority."
+    api_url:
+      type: string
+      description: "API url, that overrides the one provided by the config.yaml"
     token:
       type: string
       description: "API token, that overrides the one provided by the config.yaml"

--- a/actions/timeseries_query.yaml
+++ b/actions/timeseries_query.yaml
@@ -1,0 +1,34 @@
+---
+name: timeseries_query
+pack: scalyr
+runner_type: python-script
+description: "Run Scalyr timeseries query"
+entry_point: timeseries_query.py
+parameters:
+    filter:
+      type: string
+      description: "Timeseries query to execute"
+      required: True
+    function:
+      type: string
+      description: "Optional function to run"
+    startTime:
+      type: string
+      description: "Start of time interval, in variety of formats, e.g. 10:30, see https://www.scalyr.com/help/time-reference"
+    endTime:
+      type: string
+      description: "End of time interval, in variety of formats, e.g. 11:30, see https://www.scalyr.com/help/time-reference"
+    buckets:
+      type: integer
+      description: "Number of result buckets."
+    priority:
+      type: string
+      default: low
+      enum:
+        - "low"
+        - "high"
+      description: "Query priority."
+    token:
+      type: string
+      description: "API token, that overrides the one provided by the config.yaml"
+      secret: True

--- a/aliases/query.yaml
+++ b/aliases/query.yaml
@@ -1,0 +1,25 @@
+---
+name: "scalyr_query"
+pack: "scalyr"
+action_ref: "scalyr.query"
+description: "Run Scalyr search query."
+formats:
+    - "scalyr query {{ filter }}"
+    - "scalyr search {{ filter }}"
+result:
+  format: |
+    Results for query *{{execution.parameters.filter}}*:
+
+    {% if execution.status != "succeeded" -%}
+      Execution failed: {{ execution.result.result.message }}
+    {% else -%}
+      {% if execution.result.result.matches|length == 0 -%}
+        No results found.
+      {% else -%}
+      {% for match in execution.result.result.matches -%}
+        Message: {{ match.message }}
+      {%+ endfor %}
+      {% endif %}
+    {% endif %}
+immutable_parameters:
+  maxCount: 10

--- a/aliases/timeseries_query.yaml
+++ b/aliases/timeseries_query.yaml
@@ -1,0 +1,23 @@
+---
+name: "scalyr_timeseries_query"
+pack: "scalyr"
+action_ref: "scalyr.timeseries_query"
+description: "Run Scalyr timeseries query."
+formats:
+    - "scalyr ts {{ filter }}"
+    - "scalyr ts {{ filter }}"
+result:
+  format: |
+    Results for query *{{execution.parameters.filter}}*:
+
+    {% if execution.status != "succeeded" -%}
+      Execution failed: {{ execution.result.result.message }}
+    {% else -%}
+      {% if execution.result.result.results|length == 0 -%}
+        No results found.
+      {% else -%}
+      {% for match in execution.result.result.results -%}
+        Values: {{ match.values.join(",") }}
+      {%+ endfor %}
+      {% endif -%}
+    {% endif %}

--- a/config.schema.yaml
+++ b/config.schema.yaml
@@ -1,9 +1,9 @@
 ---
   url:
-    description: Scalyr base base URL
+    description: Scalyr base base API URL
     type: string
     required: true
-    default: https://www.scalyr.com/api
+    default: https://app.scalyr.com/api
     secret: false
   token:
     description: "Scalyr API token. Find one at https://www.scalyr.com/keys"

--- a/pack.yaml
+++ b/pack.yaml
@@ -5,7 +5,7 @@ keywords:
   - monitoring
   - observability
   - logs
-version : 0.0.2
+version : 0.1.0
 author : Scalyr, Inc.
 email : info@stackstorm.com
 contributors:


### PR DESCRIPTION
This pull request fixes ``scalyr.query`` action.

It was not passing ``Content-Type`` header to the API so it didn't work correctly. I also fixed 2 parameter names (``fromTime`` / ``toTime`` -> ``startTime`` / ``endTime``) and added 2 new parameters (``priority``, ``columns``).

I also updated the code to not log the raw value of the token under debug log level, but mask it instead.

In addition to that, I also added three new actions - ``scalyr.power_query``, ``scalyr.timeseries_query``, ``scalyr.timeseries_queries`` and 2 new action aliases.